### PR TITLE
Add message about empty tags to the README.

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -36,6 +36,11 @@ fixie.init(".string, #of > .comma, .separated, .selectors, .that, .should, #be >
 ```
 in the JavaScript console or within a `<script>` tag.
 
+You can also call Fixie on all empty elements on a page by calling:
+```
+fixie.init(':empty')
+```
+
 ## Supported Elements
 Fixie inserts the right type of content based on the tag name. Here are some major types you should be aware of:
 


### PR DESCRIPTION
In my trying out of Fixie, I've quite liked using it to replace all empty tags — to save me adding classes to my elements that I might then forget to remove. Might be worth mentioning in the `README` that you can do this?

```
fixie.init(':empty')
```
